### PR TITLE
Address Bash 4.2 issues

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -98,7 +98,7 @@ while true; do
   index=$((index + 1))
 done
 
-header "Deploying to ${target_branch@Q} on remote ${target_remote@Q}..."
+header "Deploying to '${target_branch}' on remote '${target_remote}'..."
 
 # If the user requested an ssh-keyscan, then we perform that and save the new host keys to
 # a temporary file.

--- a/lib/branches.bash
+++ b/lib/branches.bash
@@ -165,7 +165,7 @@ build-branch-config() {
 
     # If using longhand notation, the "target" option is required.
     if test -n "$match" && test -z "$target"; then
-      error "The branch ${match@Q} has no target to deploy to."
+      error "The branch '${match}' has no target to deploy to."
       error
       error "In the branch mapping array, the target option specifies which branch to"
       error "deploy to on the remote repository. This can be used to match another"
@@ -181,7 +181,7 @@ build-branch-config() {
       existing_target="$(branch-get-option "$match" target)"
       existing_remote="$(branch-get-option "$match" remote)"
 
-      error "The branch ${match@Q} already has a deployment target of ${existing_target}"
+      error "The branch '${match}' already has a deployment target of ${existing_target}"
       if test -n "$existing_remote"; then
         error "(The branch is published to ${existing_remote})"
       fi

--- a/lib/ssh.bash
+++ b/lib/ssh.bash
@@ -36,13 +36,13 @@ validate-ssh-config() {
     local port="${server[1]%$'\n'}"
 
     if ! [[ "$port" =~ ^[0-9]+$ ]]; then
-      error "The port ${port@Q} should be numeric."
+      error "The port '${port}' should be numeric."
       failures=$((failures + 1))
     fi
     ;;
 
   *)
-    error "The keyscan option ${keyscan@Q} should be in HOST or HOST:PORT format."
+    error "The keyscan option '${keyscan}' should be in HOST or HOST:PORT format."
     failures=$((failures + 1))
     ;;
   esac

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,9 +1,51 @@
-FROM buildkite/plugin-tester:latest
+FROM bash:4.2
 
-RUN apk add --no-cache git rsync
+RUN apk add --no-cache ncurses jq curl git rsync
 
+RUN curl -sSL https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz -o /tmp/bats-core.tgz \
+  && tar -zxf /tmp/bats-core.tgz -C /tmp \
+  && cd /tmp/bats-core-1.2.0 \
+  && ./install.sh /usr/local \
+  && cd / \
+  && rm -rf bats-core-1.2.0
+
+# Install bats-support
+RUN mkdir -p /usr/local/lib/bats/bats-support \
+    && curl -sSL https://github.com/ztombol/bats-support/archive/v0.3.0.tar.gz -o /tmp/bats-support.tgz \
+    && tar -zxf /tmp/bats-support.tgz -C /usr/local/lib/bats/bats-support --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-support/load.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-support.tgz
+
+# Install bats-assert
+RUN mkdir -p /usr/local/lib/bats/bats-assert \
+    && curl -sSL https://github.com/ztombol/bats-assert/archive/v0.3.0.tar.gz -o /tmp/bats-assert.tgz \
+    && tar -zxf /tmp/bats-assert.tgz -C /usr/local/lib/bats/bats-assert --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-assert/load.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-assert.tgz
+
+# Install lox's fork of bats-mock
+RUN mkdir -p /usr/local/lib/bats/bats-mock \
+    && curl -sSL https://github.com/lox/bats-mock/archive/v1.3.0.tar.gz -o /tmp/bats-mock.tgz \
+    && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-mock.tgz
+
+# Install bats-file
 RUN mkdir -p /usr/local/lib/bats/bats-file \
   && curl -sSL https://github.com/bats-core/bats-file/archive/v0.3.0.tar.gz -o /tmp/bats-file.tgz \
   && tar -xzf /tmp/bats-file.tgz -C /usr/local/lib/bats/bats-file --strip 1 \
   && printf 'source "%s"\n' "/usr/local/lib/bats/bats-file/load.bash" >> /usr/local/lib/bats/load.bash \
   && rm -rf /tmp/bats-file.tgz
+
+# Make sure /bin/bash is available, as bats/bats only has it at
+# /usr/local/bin/bash and many plugin hooks (and shellscripts in general) use
+# `#!/bin/bash` as their shebang
+RUN if [[ -e /bin/bash ]]; then echo "/bin/bash already exists"; exit 1; else ln -s /usr/local/bin/bash /bin/bash; fi
+
+# Expose BATS_PATH so people can easily use load.bash
+ENV BATS_PATH=/usr/local/lib/bats
+
+WORKDIR /plugin
+
+ENTRYPOINT []
+CMD ["bats", "tests/"]

--- a/tests/git_helper.bash
+++ b/tests/git_helper.bash
@@ -25,7 +25,7 @@ git_init() {
       ;;
 
     --*)
-      echo "Unrecognized option ${arg@Q} passed to git_init" |
+      echo "Unrecognized option '${arg}' passed to git_init" |
         batslib_decorate "ERROR: git_init" |
         fail
       return $?
@@ -185,7 +185,7 @@ git_commit() {
       ;;
 
     --*)
-      echo "Unrecognized option ${1@Q} passed to git_commit" |
+      echo "Unrecognized option '${1}' passed to git_commit" |
         batslib_decorate "ERROR: git_commit" |
         fail
       return $?


### PR DESCRIPTION
This PR addresses issues with Bash version 4.2. This is the version that is installed on Amazon Linux 2 by default, and therefore the Buildkite elastic CI stack. In order to prevent further issues from cropping up, the test suite is now run on version 4.2.

Fixes #1.
Fixes #2.