### PR TITLE
Address more error cases in ssh-keyscan

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -110,20 +110,27 @@ fi
 # Create a temporary directory
 target_directory="$(mktemp -d "$template")"
 
+# Force StrictHostKeyChecking to 'yes'. Most systems have 'ask' as the default, which will
+# cause Buildkite to wait forever on terminal input that won't come. In addition to
+# validating configuration and failing if ssh-keyscan fails, we use this as a final
+# backstop in case we don't have a copy of the remote's public key.
+ssh_command="ssh -o StrictHostKeyChecking=yes"
+
 # If we were asked to perform a keyscan, then save an ssh command that we should provide
 # to Git when cloning/pushing. Remember to use subshells when passing the ssh_command to
 # Git because we don't want to interfere with Buildkite.
-ssh_command=
 if test -n "$known_hosts_file"; then
-  ssh_command="ssh -o UserKnownHostsFile=$known_hosts_file"
+  ssh_command="$ssh_command UserKnownHostsFile=$known_hosts_file"
 fi
 
 (
   echo "--- :git: Cloning $target_remote..."
-  if test -n "$ssh_command"; then
-    GIT_SSH_COMMAND="$ssh_command"
-    export GIT_SSH_COMMAND
-  fi
+
+  # Provide the GIT_SSH_COMMAND export in a subshell to avoid overriding the agent's.
+  # (The disable directive below asserts to Shellcheck that we know what we're doing with
+  # respect to deliberately losing the environment modification.)
+  # shellcheck disable=SC2030
+  export GIT_SSH_COMMAND="$ssh_command"
 
   git clone \
     --branch "$target_branch" \
@@ -267,10 +274,9 @@ fi
 # As with the git clone, use a subshell to export the GIT_SSH_COMMAND without polluting
 # our own environment.
 (
-  if test -n "$ssh_command"; then
-    GIT_SSH_COMMAND="$ssh_command"
-    export GIT_SSH_COMMAND
-  fi
+  # Same as last time - this subshell modification is intentional.
+  # shellcheck disable=SC2031
+  export GIT_SSH_COMMAND="$ssh_command"
 
   git -C "$target_directory" push
 )

--- a/lib/ssh.bash
+++ b/lib/ssh.bash
@@ -125,4 +125,5 @@ ssh-perform-keyscan() {
 
   header "Retrieving keys from $host$sep$port..."
   ssh-keyscan "${args[@]}" >"$file"
+  return $?
 }

--- a/lib/ssh.bash
+++ b/lib/ssh.bash
@@ -24,9 +24,10 @@ validate-ssh-config() {
   local server
   IFS=: read -ra server <<<"$keyscan"
 
+  # Validate the number of required arguments (and that the port is numeric)
   case "${#server[@]}" in
   1)
-    # If we only received the host, then do nothing - we assume any host name is valid.
+    # Nothing special to do in this case (but see below)
     ;;
 
   2)
@@ -45,6 +46,20 @@ validate-ssh-config() {
     failures=$((failures + 1))
     ;;
   esac
+
+  # Does the configuration have an empty server? (If we have reached here, then the
+  # configuration is something like ":42", which won't be usable in keyscanning.)
+  if test -z "${server[0]}"; then
+    error "The server name cannot be empty"
+    failures=$((failures + 1))
+  fi
+
+  # Does the configuration have a username? This will fail (ssh-keyscan needs a bare
+  # domain name), so fail early before any downstream issues with keyscan are encountered.
+  if [[ "${server[0]}" = *@* ]]; then
+    error "The keyscan configuration should not contain a user name"
+    failures=$((failures + 1))
+  fi
 
   [ "$failures" -eq 0 ]
 }

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -27,11 +27,38 @@ teardown() {
   assert_test_success
 }
 
+@test "validate-ssh-config: keyscan=USER@HOST" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SSH_KEYSCAN=user@example.org
+
+  run validate-ssh-config
+
+  assert_failure
+  assert_line --partial "should not contain a user name"
+}
+
 @test "validate-ssh-config: keyscan=HOST:PORT" {
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SSH_KEYSCAN=example.org:123
 
   run validate-ssh-config
   assert_test_success
+}
+
+@test "validate-ssh-config: keyscan=USER@HOST:PORT" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SSH_KEYSCAN=user@example.org:123
+
+  run validate-ssh-config
+
+  assert_failure
+  assert_line --partial "should not contain a user name"
+}
+
+@test "validate-ssh-config: keyscan=:PORT" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SSH_KEYSCAN=:123
+
+  run validate-ssh-config
+
+  assert_failure
+  assert_line --partial "server name cannot be empty"
 }
 
 @test "validate-ssh-config: keyscan=HOST:PORT (port invalid)" {

--- a/tests/ssh.bats
+++ b/tests/ssh.bats
@@ -127,3 +127,17 @@ teardown() {
 
   unstub ssh-keyscan
 }
+
+@test "ssh-perform-keyscan (ssh-keyscan failure)" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SSH_KEYSCAN=domain.invalid
+
+  stub ssh-keyscan \
+    'domain.invalid : echo "getaddrinfo: domain.invalid: Name or service not known" >/dev/stderr; exit 1'
+
+  run ssh-perform-keyscan "$TEST_TMP_DIR/known_hosts"
+
+  assert_failure
+  assert_output --partial "Name or service not known"
+
+  unstub ssh-keyscan
+}


### PR DESCRIPTION
This PR addresses three related bugs related to the handling of host keys and `ssh-keyscan`.

1. During validation, we now fail if the user specified `user@host` or `user@host:port` in the ssh-keyscan configuration. This catches issues where `ssh-keyscan` would treat the `user@host` argument literally and fail to resolve otherwise valid domain names. In addition, this now correctly flags the invalid configuration `:port` (i.e., an empty server name).

2. The `ssh-perform-keyscan` function now explicitly propagates the exit code of `ssh-keyscan`, success or failure, to its caller.

3. `git` is forced to use the SSH option `StrictHostKeyChecking=yes` (the default is normally `StrictHostKeyChecking=ask`). If neither of the first two backstops identify issues, then this option will force SSH to abort if the remote's host keys were not present in the `known_hosts` file.

Tests have been added for the first two cases. The last case is much harder to write predictable tests for, so I'm leaving it as a "just in case" measure.

Fixes #4.