### PR TITLE
Add missing `-o` to options

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -120,7 +120,7 @@ ssh_command="ssh -o StrictHostKeyChecking=yes"
 # to Git when cloning/pushing. Remember to use subshells when passing the ssh_command to
 # Git because we don't want to interfere with Buildkite.
 if test -n "$known_hosts_file"; then
-  ssh_command="$ssh_command UserKnownHostsFile=$known_hosts_file"
+  ssh_command="$ssh_command -o UserKnownHostsFile=$known_hosts_file"
 fi
 
 (


### PR DESCRIPTION
This is a hotfix to #5: the exported `GIT_SSH_COMMAND` doesn't provide the `-o` for the known hosts file, causing ssh to attempt to connect to the option instead of the provided remote.