### PR TITLE
Add support for tagging builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ steps:
               target: develop # remote branch
 ```
 
-Finally, the remote can be changed on a per-branch basis in case there is a separate remote repository needed. This is the case with, for example, WP Engine's hosting environment.
+The remote can be changed on a per-branch basis in case there is a separate remote repository needed. This is the case with, for example, WP Engine's hosting environment.
 
 ```yaml
 steps:
@@ -54,6 +54,24 @@ steps:
             - match: stable
               target: master
               remote: git@example.com/remote/staging.git
+```
+
+Finally, the plugin supports a `tag:` field to dynamically create a tag. Since it goes through bash's `eval` mechanism, attention should be paid to Buildkite's [environment variable](https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation) expansion if you want the agent doing the push to expand it, instead of at pipeline upload time.
+
+```yaml
+steps:
+  - plugins:
+      - forumone/artifact-push#v0.3.1:
+          source-directory: services/drupal/web
+          remote: git@example.com/remote.git
+          branches:
+            - master # No tags here
+            - match: stable
+              target: stable
+              tag: development-$(date +%F) # Use `date` to create a timestamped release tag
+            - match: live
+              target: live
+              tag: release-$BUILDKITE_BRANCH-$BUILDKITE_BUILD_NUMBER # The hook will see "release-live-1234"
 ```
 
 If you need to perform an SSH keyscan to obtain `known_hosts` keys, use the `keyscan` option. This is useful if you are using ephemeral agents and/or are pushing to trusted hosts.

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -72,6 +72,13 @@ if test -z "$target_branch"; then
   exit 1
 fi
 
+# Get the tag from the configuration and evaluate the expression, if need be
+tag_expr="$(get-branch-tag)"
+tag=
+if test -n "$tag_expr"; then
+  tag="$(eval echo "$tag_expr")"
+fi
+
 # Build the two file lists
 files_ignore=()
 files_force_add=()
@@ -269,6 +276,10 @@ fi
     --allow-empty \
     --quiet \
     --message="$(git-commit-message)"
+
+  if test -n "$tag"; then
+    git -C "$target_directory" tag -- "$tag"
+  fi
 )
 
 # As with the git clone, use a subshell to export the GIT_SSH_COMMAND without polluting
@@ -278,5 +289,11 @@ fi
   # shellcheck disable=SC2031
   export GIT_SSH_COMMAND="$ssh_command"
 
-  git -C "$target_directory" push
+  args=("heads/$target_branch")
+
+  if test -n "$tag"; then
+    args+=("tags/$tag")
+  fi
+
+  git -C "$target_directory" push origin "${args[@]}"
 )

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,6 +27,7 @@ configuration:
           match: { type: string }
           target: { type: string }
           remote: { type: string }
+          tag: { type: string }
 
     files:
       additionalProperties: false

--- a/tests/branches.bats
+++ b/tests/branches.bats
@@ -193,3 +193,53 @@ load "../lib/branches"
 
   assert_equal "$(get-branch-remote)" "example.com"
 }
+
+@test "get-branch-tag (shorthand)" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE=example.org
+  export BUILDKITE_BRANCH=master
+
+  build-branch-config
+
+  assert_equal "$(get-branch-tag)" ""
+}
+
+@test "get-branch-tag (longhand; no tag)" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_MATCH=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_TARGET=stable
+  export BUILDKITE_BRANCH=master
+
+  build-branch-config
+
+  assert_equal "$(get-branch-tag)" ""
+}
+
+@test "get-branch-tag (longhand; no match)" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_MATCH=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_TARGET=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_BRANCH=master
+
+  build-branch-config
+
+  assert_equal "$(get-branch-tag)" ""
+}
+
+@test "get-branch-tag (longhand; match)" {
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_MATCH=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_TARGET=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_1_TAG='deploy-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_BRANCH=master
+
+  build-branch-config
+
+  assert_equal "$(get-branch-tag)" 'release-$BUILDKITE_BUILD_NUMBER'
+}

--- a/tests/hook.bats
+++ b/tests/hook.bats
@@ -95,6 +95,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
@@ -127,7 +128,7 @@ teardown() {
   assert_success
   assert_output "release-123"
 
-  assert_contents_of_file "$REMOTE_REPO/refs/heads/release-123" "$head"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-123" "$head"
 
   unstub buildkite-agent
 }
@@ -285,6 +286,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
@@ -339,9 +341,6 @@ teardown() {
 
 
 @test "hook: simple sync from root (with timestamp tag)" {
-  stub date \
-    +%F : 'echo 1234-56-78'
-
   plugin="$PWD"
 
   # Git log format: commit hash (%H) followed by commit message (%s)
@@ -364,7 +363,8 @@ teardown() {
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
-  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$(date +%F)'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$(echo 1234-56-78)'
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
   export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
 
@@ -413,8 +413,6 @@ teardown() {
 
   head="$(cat "$REMOTE_REPO/refs/heads/master")"
   assert_contents_of_file "$REMOTE_REPO/refs/tags/release-1234-56-78" "$head"
-
-  unstub date
 }
 
 @test "hook: simple sync from nested" {

--- a/tests/hook.bats
+++ b/tests/hook.bats
@@ -57,6 +57,7 @@ teardown() {
   # 1. The plugin exited cleanly
   # 2. The user has been notified
   # 3. The remote repository has a new (empty) commit
+  # 4. No new tags were created on the remote
   assert_success
   assert_line --partial "Git reports no changes."
 
@@ -66,6 +67,67 @@ teardown() {
   run git -C "$REMOTE_REPO" show --raw --format=%H "$head"
   assert_success
   assert_output "$head"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+
+  unstub buildkite-agent
+}
+
+@test "hook: no changes (with tag)" {
+  stub buildkite-agent \
+    'annotate --style=warning : true'
+
+  plugin="$PWD"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo
+  git_commit "$REMOTE_CLONE" bar
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  remote_head="$(cat "$REMOTE_REPO/refs/heads/master")"
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo
+  git_commit "$SOURCE_REPO" bar
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  # Assertions:
+  # 1. The plugin exited cleanly
+  # 2. The user has been notified
+  # 3. The remote repository has a new (empty) commit
+  # 4. The remote repository has a new tag named release-123 matching the new commit
+  assert_success
+  assert_line --partial "Git reports no changes."
+
+  refute_contents_of_file "$REMOTE_REPO/refs/heads/master" "$remote_head"
+  head="$(cat "$REMOTE_REPO/refs/heads/master")"
+
+  run git -C "$REMOTE_REPO" show --raw --format=%H "$head"
+  assert_success
+  assert_output "$head"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-123"
+
+  assert_contents_of_file "$REMOTE_REPO/refs/heads/release-123" "$head"
 
   unstub buildkite-agent
 }
@@ -111,6 +173,7 @@ teardown() {
   # 1. The plugin exited cleanly
   # 2. The user has been notified
   # 3. The remote repository has a new (empty) commit
+  # 4. No tags were created on the remote
   assert_success
   assert_line --partial "Git reports no changes."
 
@@ -121,6 +184,10 @@ teardown() {
 
   assert_success
   assert_output "$head"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 
   unstub buildkite-agent
 }
@@ -170,6 +237,7 @@ teardown() {
   #    3. The commit that introduced bar on the source is not present in the remote logs
   # 3. The most recent commit to the remote mentions the default commit message format
   # 4. The most recent commit was authored by the plugin's git user and email
+  # 5. No tags were created on the remote
   run git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
   assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
@@ -188,6 +256,165 @@ teardown() {
   run git -C "$REMOTE_CLONE" log --format="%an <%ae>" --max-count=1
   assert_success
   assert_output "bats <bats@localhost.localdomain>"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+}
+
+@test "hook: simple sync from root (with tag)" {
+  plugin="$PWD"
+
+  # Git log format: commit hash (%H) followed by commit message (%s)
+  format="%H %s"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo --message "REMOTE - add foo"
+  git_commit "$REMOTE_CLONE" bar --message "REMOTE - add bar"
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  remote_log="$(git -C "$REMOTE_CLONE" log --format="$format")"
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo --contents "source foo" --message "SOURCE - update foo"
+  source_foo_commit="$(git -C "$SOURCE_REPO" log --format="$format" --max-count=1)"
+
+  git_commit "$SOURCE_REPO" bar --contents "source bar" --message "SOURCE - update bar"
+  source_bar_commit="$(git -C "$SOURCE_REPO" log --format="$format" --max-count=1)"
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  assert_success
+
+  # Assertions:
+  # 1. The foo and bar files have been updated on the remote
+  # 2. The remote's git log has not been corrupted or synchronized with the source:
+  #    1. The original remote log still applies
+  #    2. The commit that introduced foo on the source is not present in the remote logs
+  #    3. The commit that introduced bar on the source is not present in the remote logs
+  # 3. The most recent commit to the remote mentions the default commit message format
+  # 4. The most recent commit was authored by the plugin's git user and email
+  # 5. The tag release-123 has the same commit as the new remote commit
+  run git -C "$REMOTE_CLONE" pull
+  assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
+
+  run git -C "$REMOTE_CLONE" log --format="$format"
+  assert_success
+  assert_equal "${#lines[@]}" 3 # foo + bar + rsync
+  assert_output --partial "$remote_log"
+  refute_line "$source_foo_commit"
+  refute_line "$source_bar_commit"
+
+  run git -C "$REMOTE_CLONE" log --format=%s --max-count=1
+  assert_success
+  assert_line --partial "bats/artifact-push"
+
+  run git -C "$REMOTE_CLONE" log --format="%an <%ae>" --max-count=1
+  assert_success
+  assert_output "bats <bats@localhost.localdomain>"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-123"
+
+  head="$(cat "$REMOTE_REPO/refs/heads/master")"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-123" "$head"
+}
+
+
+
+@test "hook: simple sync from root (with timestamp tag)" {
+  stub date \
+    +%F : 'echo 1234-56-78'
+
+  plugin="$PWD"
+
+  # Git log format: commit hash (%H) followed by commit message (%s)
+  format="%H %s"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo --message "REMOTE - add foo"
+  git_commit "$REMOTE_CLONE" bar --message "REMOTE - add bar"
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  remote_log="$(git -C "$REMOTE_CLONE" log --format="$format")"
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo --contents "source foo" --message "SOURCE - update foo"
+  source_foo_commit="$(git -C "$SOURCE_REPO" log --format="$format" --max-count=1)"
+
+  git_commit "$SOURCE_REPO" bar --contents "source bar" --message "SOURCE - update bar"
+  source_bar_commit="$(git -C "$SOURCE_REPO" log --format="$format" --max-count=1)"
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$(date +%F)'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  assert_success
+
+  # Assertions:
+  # 1. The foo and bar files have been updated on the remote
+  # 2. The remote's git log has not been corrupted or synchronized with the source:
+  #    1. The original remote log still applies
+  #    2. The commit that introduced foo on the source is not present in the remote logs
+  #    3. The commit that introduced bar on the source is not present in the remote logs
+  # 3. The most recent commit to the remote mentions the default commit message format
+  # 4. The most recent commit was authored by the plugin's git user and email
+  # 5. The tag release-123 has the same commit as the new remote commit
+  run git -C "$REMOTE_CLONE" pull
+  assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
+
+  run git -C "$REMOTE_CLONE" log --format="$format"
+  assert_success
+  assert_equal "${#lines[@]}" 3 # foo + bar + rsync
+  assert_output --partial "$remote_log"
+  refute_line "$source_foo_commit"
+  refute_line "$source_bar_commit"
+
+  run git -C "$REMOTE_CLONE" log --format=%s --max-count=1
+  assert_success
+  assert_line --partial "bats/artifact-push"
+
+  run git -C "$REMOTE_CLONE" log --format="%an <%ae>" --max-count=1
+  assert_success
+  assert_output "bats <bats@localhost.localdomain>"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-1234-56-78"
+
+  head="$(cat "$REMOTE_REPO/refs/heads/master")"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-1234-56-78" "$head"
+
+  unstub date
 }
 
 @test "hook: simple sync from nested" {
@@ -224,6 +451,7 @@ teardown() {
   # 1. The foo and bar files have been copied into the remote's root
   # 2. Neither the nested/ directory nor the baz file has been copied.
   # 3. The only contents of the remote are the foo and bar files
+  # 4. No tags were created on the remote
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
   assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
@@ -236,6 +464,10 @@ teardown() {
 bar
 foo
 OUTPUT
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: simple sync with deletions" {
@@ -270,10 +502,15 @@ OUTPUT
   # Assertions:
   # 1. The file "foo" is untouched (same contents)
   # 2. The files "bar" and "baz" have been deleted from the remote
+  # 3. No tags were created on the remote
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" foo
   assert_file_not_exist "$REMOTE_CLONE/bar"
   assert_file_not_exist "$REMOTE_CLONE/baz"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: simple sync with additions" {
@@ -307,10 +544,15 @@ OUTPUT
 
   # Assertions:
   # 1. All three of foo, bar, and baz have been copied over to the remote
+  # 2. No tags were created on the remote
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" foo
   assert_contents_of_file "$REMOTE_CLONE/bar" bar
   assert_contents_of_file "$REMOTE_CLONE/baz" baz
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: sync master to stable" {
@@ -357,6 +599,7 @@ OUTPUT
   # 2. The remote's stable branch _has_ been updated
   # 3. On stable, the foo and bar files have been updated
   # 4. On master, no file has been touched
+  # 5. No tags were created on the remote
   assert_contents_of_file "$REMOTE_REPO/refs/heads/master" "$master_ref"
   refute_contents_of_file "$REMOTE_REPO/refs/heads/stable" "$stable_ref"
 
@@ -370,6 +613,78 @@ OUTPUT
   assert_contents_of_file "$REMOTE_CLONE/foo" "master foo"
   assert_file_not_exist "$REMOTE_CLONE/bar"
   assert_contents_of_file "$REMOTE_CLONE/baz" "master baz"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+}
+
+@test "hook: sync master to stable (with tag)" {
+  plugin="$PWD"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo --contents "master foo"
+  git_commit "$REMOTE_CLONE" baz --contents "master baz"
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  master_ref="$(cat "$REMOTE_REPO/refs/heads/master")"
+
+  git -C "$REMOTE_CLONE" checkout -b stable
+  git_commit "$REMOTE_CLONE" foo --contents "stable foo"
+  git_commit "$REMOTE_CLONE" bar --contents "stable bar"
+  git -C "$REMOTE_CLONE" push --set-upstream origin stable
+
+  stable_ref="$(cat "$REMOTE_REPO/refs/heads/stable")"
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo --contents "source foo"
+  git_commit "$SOURCE_REPO" bar --contents "source bar"
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  assert_success
+
+  # Assertions:
+  # 1. The remote's master branch has not been updated (refs/heads/<branch> = most recent commit ID)
+  # 2. The remote's stable branch _has_ been updated
+  # 3. On stable, the foo and bar files have been updated
+  # 4. On master, no file has been touched
+  # 5. The tag release-123 has the most recent commit to stable
+  assert_contents_of_file "$REMOTE_REPO/refs/heads/master" "$master_ref"
+  refute_contents_of_file "$REMOTE_REPO/refs/heads/stable" "$stable_ref"
+
+  git -C "$REMOTE_CLONE" pull
+  assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
+
+  git -C "$REMOTE_CLONE" checkout master
+  git -C "$REMOTE_CLONE" pull
+
+  assert_contents_of_file "$REMOTE_CLONE/foo" "master foo"
+  assert_file_not_exist "$REMOTE_CLONE/bar"
+  assert_contents_of_file "$REMOTE_CLONE/baz" "master baz"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-123"
+
+  head="$(cat "$REMOTE_REPO/refs/heads/stable")"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-123" "$head"
 }
 
 @test "hook: separate remotes" {
@@ -415,6 +730,7 @@ OUTPUT
   # Assertions:
   # 1. The bare repo in $PRISTINE_REPO has no new objects or branches
   # 2. The remote repository was updated properly
+  # 3. No tags were created on the remote
   assert_file_not_exist "$PRISTINE_REPO/refs/heads/master"
   run ls "$PRISTINE_REPO/refs/heads"
   assert_success
@@ -423,6 +739,77 @@ OUTPUT
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" "new foo"
   assert_contents_of_file "$REMOTE_CLONE/bar" "new bar"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+}
+
+@test "hook: separate remotes (with tag)" {
+  teardown() {
+    git_cleanup "$SOURCE_REPO"
+    git_cleanup "$REMOTE_REPO"
+    git_cleanup "$REMOTE_CLONE"
+    git_cleanup "$PRISTINE_REPO"
+  }
+
+  plugin="$PWD"
+
+  PRISTINE_REPO="$(git_init --bare)"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo
+  git_commit "$REMOTE_CLONE" bar
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo --contents "new foo"
+  git_commit "$SOURCE_REPO" bar --contents "new bar"
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$PRISTINE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  assert_success
+
+  # Assertions:
+  # 1. The bare repo in $PRISTINE_REPO has no new objects or branches
+  # 2. The remote repository was updated properly
+  # 3. No release-123 tag was created for the pristine repo
+  # 4. The remote repository's release-123 tag matches the pushed commit
+  assert_file_not_exist "$PRISTINE_REPO/refs/heads/master"
+  run ls "$PRISTINE_REPO/refs/heads"
+  assert_success
+  assert_output ""
+
+  git -C "$REMOTE_CLONE" pull
+  assert_contents_of_file "$REMOTE_CLONE/foo" "new foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "new bar"
+
+  run ls "$PRISTINE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-123"
+
+  head="$(cat "$REMOTE_REPO/refs/heads/master")"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-123" "$head"
 }
 
 @test "hook: separate remotes with branch override" {
@@ -474,6 +861,7 @@ OUTPUT
   # 1. The bare repo in $PRISTINE_REPO has no new objects or branches
   # 2. The remote repository was updated properly
   # 3. The master branch has not been perturbed on the remote
+  # 4. No tags were created
   assert_file_not_exist "$PRISTINE_REPO/refs/heads/master"
   assert_file_not_exist "$PRISTINE_REPO/refs/heads/stable"
   run ls "$PRISTINE_REPO/refs/heads"
@@ -489,6 +877,85 @@ OUTPUT
   assert_output "Already up to date."
   assert_contents_of_file "$REMOTE_CLONE/foo" "master foo"
   assert_contents_of_file "$REMOTE_CLONE/bar" "master bar"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
+}
+
+@test "hook: separate remotes with branch override (with tag)" {
+  teardown() {
+    git_cleanup "$SOURCE_REPO"
+    git_cleanup "$REMOTE_REPO"
+    git_cleanup "$REMOTE_CLONE"
+    git_cleanup "$PRISTINE_REPO"
+  }
+
+  plugin="$PWD"
+
+  PRISTINE_REPO="$(git_init --bare)"
+
+  git -C "$REMOTE_CLONE" checkout -b master
+  git_commit "$REMOTE_CLONE" foo --contents "master foo"
+  git_commit "$REMOTE_CLONE" bar --contents "master bar"
+  git -C "$REMOTE_CLONE" push --set-upstream origin master
+
+  git -C "$REMOTE_CLONE" checkout -b stable
+  git_commit "$REMOTE_CLONE" foo --contents "stable foo"
+  git_commit "$REMOTE_CLONE" bar --contents "stable bar"
+  git -C "$REMOTE_CLONE" push --set-upstream origin stable
+
+  git -C "$SOURCE_REPO" checkout -b master
+  git_commit "$SOURCE_REPO" foo --contents "new foo"
+  git_commit "$SOURCE_REPO" bar --contents "new bar"
+
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_REMOTE="file://$PRISTINE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_SOURCE_DIRECTORY=.
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_MATCH=master
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TARGET=stable
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_REMOTE="file://$REMOTE_REPO"
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_BRANCHES_0_TAG='release-$BUILDKITE_BUILD_NUMBER'
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_NAME=bats
+  export BUILDKITE_PLUGIN_ARTIFACT_PUSH_GIT_EMAIL=bats@localhost.localdomain
+
+  export BUILDKITE_ORGANIZATION_SLUG=bats
+  export BUILDKITE_PIPELINE_SLUG=artifact-push
+  export BUILDKITE_BUILD_NUMBER=123
+  export BUILDKITE_BRANCH=master
+
+  pushd "$SOURCE_REPO"
+  run "$plugin/hooks/post-command"
+  popd
+
+  assert_success
+
+  # Assertions:
+  # 1. The bare repo in $PRISTINE_REPO has no new objects or branches
+  # 2. The remote repository was updated properly
+  # 3. The master branch has not been perturbed on the remote
+  # 4. The release-123 tag has the same commit as the new push to stable
+  assert_file_not_exist "$PRISTINE_REPO/refs/heads/master"
+  assert_file_not_exist "$PRISTINE_REPO/refs/heads/stable"
+  run ls "$PRISTINE_REPO/refs/heads"
+  assert_success
+  assert_output ""
+
+  git -C "$REMOTE_CLONE" pull
+  assert_contents_of_file "$REMOTE_CLONE/foo" "new foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "new bar"
+
+  git -C "$REMOTE_CLONE" checkout master
+  run git -C "$REMOTE_CLONE" pull
+  assert_output "Already up to date."
+  assert_contents_of_file "$REMOTE_CLONE/foo" "master foo"
+  assert_contents_of_file "$REMOTE_CLONE/bar" "master bar"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output "release-123"
+
+  head="$(cat "$REMOTE_REPO/refs/heads/stable")"
+  assert_contents_of_file "$REMOTE_REPO/refs/tags/release-123" "$head"
 }
 
 @test "hook: custom commit message" {
@@ -520,13 +987,18 @@ OUTPUT
   assert_success
 
   # Assertions:
-  # Our commit message appears in the remote's log
+  # 1. Our commit message appears in the remote's log
+  # 2. No tags were created
   git -C "$REMOTE_CLONE" pull
   run git -C "$REMOTE_CLONE" log --format="%s"
   cat <<OUTPUT | assert_output
 Custom commit
 foo
 OUTPUT
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: ignore list" {
@@ -562,9 +1034,14 @@ OUTPUT
   # Assertions:
   # 1. The file "foo" was updated on the remote
   # 2. The file "precious" was not deleted despite not existing in the source
+  # 3. No tags were created on the remote
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" "new foo"
   assert_contents_of_file "$REMOTE_CLONE/precious" "precious"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: force-add list" {
@@ -606,11 +1083,16 @@ OUTPUT
   # 1. The files "foo" and "bar" were copied over
   # 2. The artifact file was force-added and copied over
   # 3. The cruft file was not copied over
+  # 4. No tags were created on the remote
   git -C "$REMOTE_CLONE" pull
   assert_contents_of_file "$REMOTE_CLONE/foo" "source foo"
   assert_contents_of_file "$REMOTE_CLONE/bar" "source bar"
   assert_contents_of_file "$REMOTE_CLONE/artifact" "artifact"
   assert_file_not_exist "$REMOTE_CLONE/cruft"
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: branches=[]" {
@@ -639,6 +1121,10 @@ OUTPUT
   run ls "$REMOTE_REPO/refs/heads"
   assert_success
   assert_output ""
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: branches=[] and require-branch" {
@@ -657,13 +1143,18 @@ OUTPUT
   run "hooks/post-command"
 
   # Assertions:
-  # The plugin failed
+  # 1. The plugin failed
+  # 2. No objects or tags were created
   assert_failure
   assert_line --partial "No branch mappings"
   assert_line --partial "branch to deploy to"
   assert_line --partial "Branch mappings:"
 
   run ls "$REMOTE_REPO/refs/heads"
+  assert_success
+  assert_output ""
+
+  run ls "$REMOTE_REPO/refs/tags"
   assert_success
   assert_output ""
 }
@@ -694,6 +1185,10 @@ OUTPUT
   run ls "$REMOTE_REPO/refs/heads"
   assert_success
   assert_output ""
+
+  run ls "$REMOTE_REPO/refs/tags"
+  assert_success
+  assert_output ""
 }
 
 @test "hook: no matching branch and require-branch" {
@@ -718,6 +1213,10 @@ OUTPUT
   assert_failure
   assert_line --partial "Current branch: stable"
   assert_line --partial "  * master: Deploys to branch master on remote file://$REMOTE_REPO"
+
+  run ls "$REMOTE_REPO/refs/heads"
+  assert_success
+  assert_output ""
 
   run ls "$REMOTE_REPO/refs/heads"
   assert_success


### PR DESCRIPTION
This PR adds functionality for builds pushed by this plugin to also apply a tag. The tag is evaluated as a Bash expression, allowing tags to be timestamped with the `date` command.

An example is added to the README file.